### PR TITLE
MUL-1831: ISO8601 time parsing fix

### DIFF
--- a/multy_core/error.h
+++ b/multy_core/error.h
@@ -89,6 +89,8 @@ enum ErrorCode
     ERROR_INVALID_ADDRESS,                      // blockhain account address is invalid
 
     ERROR_NOT_ALL_REQUIRED_PROPERTIES_SET,
+    ERROR_INVALID_TIME_STRING,
+    // NOTE: ^^^ Add new generic error codes above this line. ^^^
 
     // Scope-specific error codes
 

--- a/multy_core/src/golos/golos_transaction.cpp
+++ b/multy_core/src/golos/golos_transaction.cpp
@@ -23,52 +23,12 @@
 #include <chrono>
 #include <cstddef>
 #include <cstring>
-#include <ctime>
-#include <iomanip>
-#include <sstream>
 #include <unordered_map>
 
 namespace multy_core
 {
 namespace internal
 {
-
-const char* ISO8601_TIME_FORMAT="%FT%T%z";
-
-std::string format_iso8601_string(const std::time_t& time)
-{
-    std::ostringstream ss;
-    ss << std::put_time(std::gmtime(&time), ISO8601_TIME_FORMAT);
-
-    return ss.str();
-}
-
-std::time_t parse_iso8601_string(const std::string& str)
-{
-    std::tm tm;
-    std::istringstream ss(str);
-    ss >> std::get_time(&tm, ISO8601_TIME_FORMAT);
-    const auto result = std::mktime(&tm);
-    if (result < 0)
-    {
-        THROW_EXCEPTION("Invalid ISO8601 date/time value.");
-    }
-
-    return result;
-}
-
-std::time_t to_system_seconds(size_t seconds)
-{
-    return std::chrono::system_clock::to_time_t(
-            std::chrono::system_clock::from_time_t(0)
-            + std::chrono::seconds(seconds));
-}
-
-std::time_t get_system_time_now()
-{
-    return std::chrono::system_clock::to_time_t(
-            std::chrono::system_clock::now());
-}
 
 class GolosBinaryStream
 {

--- a/multy_core/src/utility.cpp
+++ b/multy_core/src/utility.cpp
@@ -20,8 +20,12 @@
 #include "wally_core.h"
 
 #include <cassert>
+#include <chrono>
+#include <ctime>
 #include <string>
 #include <string.h>
+#include <sstream>
+#include <iomanip>
 
 namespace
 {
@@ -158,6 +162,126 @@ std::string to_string(GolosNetType net_type)
 
     return GOLOS_NET_TYPE_NAMES.get_name_or_dummy(net_type);
 }
+
+namespace
+{
+const char* ISO8601_TIME_FORMAT="%FT%T";
+
+std::time_t get_timezone_offset()
+{
+    // local time
+    static const auto t0 = std::time(nullptr);
+    // global time (UTC)
+    static const auto t1 = std::mktime(std::gmtime(&t0));
+
+    return t0 - t1;
+}
+
+struct ExpectedSymbol
+{
+    const char symbol;
+};
+
+std::istream& operator>>(std::istream& istr, const ExpectedSymbol& expected)
+{
+    char c = '\0';
+    istr >> c;
+    if (c != expected.symbol)
+    {
+        THROW_EXCEPTION("Unexpected symbol.")
+                << " At position: " << istr.tellg()
+                << " expected: '" << expected.symbol
+                << "' got: '" << c << "'";
+    }
+
+    return istr;
+}
+} // namespace
+
+std::string format_iso8601_string(const std::time_t& time)
+{
+    std::ostringstream ss;
+    ss << std::put_time(std::gmtime(&time), ISO8601_TIME_FORMAT);
+
+    return ss.str();
+}
+
+std::time_t parse_iso8601_string(const std::string& str)
+{
+    std::string time_string = str;
+
+    bool global_time = false;
+    // UTC (Zulu-time)
+    if (time_string.length() > 0 && time_string.back() == 'Z')
+    {
+        global_time = true;
+        time_string.pop_back();
+    }
+
+    std::tm tm;
+    memset(&tm, 0, sizeof(tm));
+
+    std::istringstream ss(time_string);
+    try
+    {
+        ss.exceptions(std::ios::failbit | std::ios::badbit);
+
+        ss >> tm.tm_year >> ExpectedSymbol{'-'}
+            >> tm.tm_mon >> ExpectedSymbol{'-'}
+            >> tm.tm_mday >> ExpectedSymbol{'T'}
+            >> tm.tm_hour >> ExpectedSymbol{':'}
+            >> tm.tm_min >> ExpectedSymbol{':'}
+            >> tm.tm_sec;
+        if (!ss.eof())
+        {
+            THROW_EXCEPTION2(ERROR_INVALID_TIME_STRING,
+                    "Failed to parse ISO8601 time.")
+                    << " Leftovers after parsing: \"" << ss.str() << "\".";
+        }
+
+        tm.tm_year -= 1900;
+        tm.tm_mon -= 1;
+    } catch (const std::exception& e) {
+        THROW_EXCEPTION2(ERROR_INVALID_TIME_STRING,
+                "Failed to parse ISO8601-time.")
+                << " " << e.what();
+    }
+    if (tm.tm_year < 0
+        || tm.tm_mon < 0 || tm.tm_mon > 11
+        || tm.tm_mday < 1 || tm.tm_mday > 31
+        || tm.tm_hour < 0 || tm.tm_hour > 23
+        || tm.tm_min < 0 || tm.tm_min > 59
+        || tm.tm_sec < 0 || tm.tm_sec > 60)
+    {
+        THROW_EXCEPTION2(ERROR_INVALID_TIME_STRING,
+                "Failed to parse ISO8601-time.")
+                << " Value is out of range: " << str;
+    }
+
+    const auto result = std::mktime(&tm);
+    if (result < 0)
+    {
+        THROW_EXCEPTION2(ERROR_INVALID_TIME_STRING,
+                "Invalid ISO8601 date/time value.");
+    }
+
+    // mktime() converts to localtime, adding timezone offset to make global time.
+    return result + (global_time ? get_timezone_offset() : 0);
+}
+
+std::time_t to_system_seconds(size_t seconds)
+{
+    return std::chrono::system_clock::to_time_t(
+            std::chrono::system_clock::from_time_t(0)
+            + std::chrono::seconds(seconds));
+}
+
+std::time_t get_system_time_now()
+{
+    return std::chrono::system_clock::to_time_t(
+            std::chrono::system_clock::now());
+}
+
 
 void trim_excess_trailing_null(std::string* str)
 {

--- a/multy_core/src/utility.h
+++ b/multy_core/src/utility.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <string>
 #include <sstream>
+#include <ctime>
 
 extern "C" struct BlockchainType;
 
@@ -209,6 +210,12 @@ MULTY_CORE_API std::string to_string(Blockchain blockchain);
 MULTY_CORE_API std::string to_string(BitcoinNetType net_type);
 MULTY_CORE_API std::string to_string(EthereumChainId net_type);
 MULTY_CORE_API std::string to_string(GolosNetType net_type);
+
+MULTY_CORE_API std::string format_iso8601_string(const std::time_t& time);
+MULTY_CORE_API std::time_t parse_iso8601_string(const std::string& str);
+
+std::time_t to_system_seconds(size_t seconds);
+std::time_t get_system_time_now();
 
 // remove excess '\0' chars at end of string.
 void trim_excess_trailing_null(std::string* str);


### PR DESCRIPTION
Fixed implementation of parse_iso8601_string()
Moved it to utility.h/cpp
Added test cases for parse_iso8601_string()