### PR TITLE
MUL-1906: Implement Ethereum personal_sign

### DIFF
--- a/multy_core/CMakeLists.txt
+++ b/multy_core/CMakeLists.txt
@@ -52,6 +52,7 @@ set(MULTY_CORE_SOURCES
     src/api/blockchain.cpp
     src/api/common.cpp
     src/api/error.cpp
+    src/api/ethereum.cpp
     src/api/key.cpp
     src/api/key_impl.cpp
     src/api/mnemonic.cpp

--- a/multy_core/ethereum.h
+++ b/multy_core/ethereum.h
@@ -7,11 +7,14 @@
 #ifndef MULTY_CORE_ETHEREUM_H
 #define MULTY_CORE_ETHEREUM_H
 
+#include "multy_core/api.h"
 #include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+struct Error;
 
 enum EthereumChainId
 {
@@ -37,6 +40,19 @@ enum EthereumTransactionBuilderType
 };
 
 const size_t ETHEREUM_BINARY_ADDRESS_SIZE = 20;
+
+/** The sign method calculates an Ethereum specific signature
+ * compatitable with geth/partity 'personal_sign' and web3.js.
+
+ @param serialized_private_key - serialized Ethereum private key.
+ @param hex_encoded_message - hex-encoded message to sign (may contain 0x prefix).
+ @param signature - OUT hex-encoded signature, with recovery_id set to 27 or 28.
+ @return nullptr if no error Error object otherwise.
+*/
+MULTY_CORE_API struct Error* ethereum_personal_sign(
+        const char* serialized_private_key,
+        const char* hex_encoded_message,
+        char** signature);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/multy_core/src/api/binary_data.cpp
+++ b/multy_core/src/api/binary_data.cpp
@@ -9,6 +9,7 @@
 #include "multy_core/src/codec.h"
 #include "multy_core/src/u_ptr.h"
 #include "multy_core/src/utility.h"
+#include "multy_core/src/binary_data_utility.h"
 
 #include "wally_core.h"
 
@@ -26,42 +27,37 @@ Error* make_binary_data_clone(const BinaryData* source, BinaryData** new_binary_
             source->data, source->len, new_binary_data);
 }
 
-Error* make_binary_data(size_t size, BinaryData** new_binary_data)
+Error* make_binary_data(size_t size, BinaryData** out_new_binary_data)
 {
-    ARG_CHECK(new_binary_data);
+    ARG_CHECK(out_new_binary_data != nullptr);
     try
     {
-        std::unique_ptr<unsigned char[]> data(new unsigned char[size]);
-        wally_bzero(data.get(), size);
-        *new_binary_data = new BinaryData{data.get(), size};
-
-        data.release();
+        *out_new_binary_data = new_binary_data(size).release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_GENERIC);
 
-    OUT_CHECK(*new_binary_data);
+    OUT_CHECK(*out_new_binary_data);
 
     return nullptr;
 }
 
 Error* make_binary_data_from_bytes(
-        const unsigned char* data, size_t size, BinaryData** new_binary_data)
+        const unsigned char* data, size_t size, BinaryData** out_new_binary_data)
 {
     ARG_CHECK(size == 0 || data);
-    ARG_CHECK(new_binary_data);
+    ARG_CHECK(out_new_binary_data != nullptr);
     try
     {
-        BinaryDataPtr result;
-        throw_if_error(make_binary_data(size, reset_sp(result)));
+        BinaryDataPtr result = new_binary_data(size);
         if (result->data && size != 0)
         {
             memcpy(const_cast<unsigned char*>(result->data), data, size);
         }
-        *new_binary_data = result.release();
+        *out_new_binary_data = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_GENERIC);
 
-    OUT_CHECK(*new_binary_data);
+    OUT_CHECK(*out_new_binary_data);
 
     return nullptr;
 }

--- a/multy_core/src/api/ethereum.cpp
+++ b/multy_core/src/api/ethereum.cpp
@@ -1,0 +1,79 @@
+/* Copyright 2018 by Multy.io
+ * Licensed under Multy.io license.
+ *
+ * See LICENSE for details
+ */
+
+#include "multy_core/ethereum.h"
+#include "multy_core/error.h"
+
+#include "multy_core/src/account_base.h"
+#include "multy_core/src/blockchain_facade_base.h"
+#include "multy_core/src/codec.h"
+#include "multy_core/src/hash.h"
+#include "multy_core/src/api/key_impl.h"
+#include "multy_core/src/utility.h"
+#include "multy_core/src/u_ptr.h"
+
+#include <memory>
+#include <string>
+#include <string.h>
+
+namespace
+{
+using namespace multy_core::internal;
+
+std::string ethereum_personal_sign_impl(
+        const char* serialized_private_key,
+        const char* hex_encoded_message)
+{
+    INVARIANT(serialized_private_key != nullptr);
+    INVARIANT(hex_encoded_message != nullptr);
+
+    // We can use any Ethereum net type, that makes no difference in signature.
+    const BlockchainType blockchain_type{BLOCKCHAIN_ETHEREUM, ETHEREUM_CHAIN_ID_ETC_MAINNET};
+    AccountPtr account = get_blockchain(blockchain_type).make_account(blockchain_type, 0, serialized_private_key);
+
+    BinaryDataPtr decoded_message = decode(hex_encoded_message, strlen(hex_encoded_message), CODEC_HEX);
+     // Padded from right with zeroes to allow more space for message length.
+    const char format[] = "\u0019Ethereum Signed Message:\n%zd";
+    char buffer[sizeof(format) + 10] = {'\0'};
+
+    const auto f = snprintf(buffer, sizeof(buffer) - 1, format, decoded_message->len);
+    if (f >= static_cast<int>(sizeof(buffer)) || f  < 0)
+    {
+        THROW_EXCEPTION2(ERROR_GENERAL_ERROR, "Failed to format message for Ethereum personal_sign.");
+    }
+
+    BinaryDataPtr message = new_binary_data(strlen(buffer) + decoded_message->len);
+    memcpy(const_cast<unsigned char*>(message->data), buffer, strlen(buffer));
+    memcpy(const_cast<unsigned char*>(message->data + strlen(buffer)), decoded_message->data, decoded_message->len);
+
+    BinaryDataPtr signature = account->get_private_key()->sign(*message);
+    const_cast<unsigned char*>(signature->data)[64] += 27;
+
+    return encode(*signature, CODEC_HEX);
+}
+
+} // namespace
+
+
+Error* ethereum_personal_sign(
+        const char* serialized_private_key,
+        const char* hex_encoded_message,
+        char** signature)
+{
+    ARG_CHECK(serialized_private_key != nullptr);
+    ARG_CHECK(hex_encoded_message != nullptr);
+    ARG_CHECK(signature != nullptr);
+
+    try
+    {
+        *signature = copy_string(ethereum_personal_sign_impl(serialized_private_key, hex_encoded_message));
+    }
+    CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_ACCOUNT);
+
+    OUT_CHECK(*signature != nullptr);
+
+    return nullptr;
+}

--- a/multy_core/src/api/key.cpp
+++ b/multy_core/src/api/key.cpp
@@ -99,6 +99,29 @@ Error* key_to_string(const Key* key, const char** new_str)
     return nullptr;
 }
 
+Error* sign_with_key(const Key* key, const BinaryData* data,
+        BinaryData** new_signature)
+{
+    ARG_CHECK_OBJECT(key);
+    ARG_CHECK(data != nullptr);
+    ARG_CHECK(new_signature != nullptr);
+
+    try
+    {
+        const PrivateKey* pk = dynamic_cast<const PrivateKey*>(key);
+        if (!pk)
+        {
+            THROW_EXCEPTION2(ERROR_INVALID_ARGUMENT, "Key is not a PrivateKey.");
+        }
+
+        *new_signature = pk->sign(*data).release();
+    }
+    CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_KEY);
+    OUT_CHECK(*new_signature);
+
+    return nullptr;
+}
+
 //Error* sign_with_key(
 //        const Key* key, const BinaryData* data, BinaryData** new_signature)
 //{

--- a/multy_core/src/binary_data_utility.cpp
+++ b/multy_core/src/binary_data_utility.cpp
@@ -11,6 +11,7 @@
 #include "multy_core/src/exception.h"
 #include "multy_core/src/exception_stream.h"
 
+#include "wally_core.h"
 #include <string.h>
 
 namespace multy_core
@@ -71,6 +72,17 @@ bool operator==(const BinaryData& left, const BinaryData& right)
 {
     return left.len == right.len
             && memcmp(left.data, right.data, left.len) == 0;
+}
+
+BinaryDataPtr new_binary_data(size_t size)
+{
+    std::unique_ptr<unsigned char[]> data(new unsigned char[size]);
+    wally_bzero(data.get(), size);
+
+    BinaryDataPtr result(new BinaryData{data.get(), size});
+    data.release();
+
+    return result;
 }
 
 } // namespace internal

--- a/multy_core/src/binary_data_utility.h
+++ b/multy_core/src/binary_data_utility.h
@@ -13,6 +13,7 @@
 
 #include "multy_core/api.h"
 #include "multy_core/binary_data.h"
+#include "multy_core/src/u_ptr.h"
 
 #include <array>
 #include <string>
@@ -102,6 +103,8 @@ inline const BinaryData& as_binary_data(const BinaryData& binary_data)
 {
     return binary_data;
 }
+
+BinaryDataPtr new_binary_data(size_t bytes);
 
 MULTY_CORE_API bool operator==(const BinaryData& left, const BinaryData& right);
 inline bool operator!=(const BinaryData& left, const BinaryData& right)

--- a/multy_core/src/codec.cpp
+++ b/multy_core/src/codec.cpp
@@ -12,9 +12,26 @@ extern "C" {
 #include "ccan/str/base32/base32.h"
 } // extern "C"
 
+#include <string.h>
+
 namespace
 {
 using namespace multy_core::internal;
+
+const char* skip_prefix(const char* prefix, const char* str, size_t* str_len)
+{
+    INVARIANT(prefix != nullptr);
+    INVARIANT(str != nullptr);
+
+    const auto prefix_size = strlen(prefix);
+    if (prefix_size <= *str_len && strncmp(str, prefix, prefix_size) == 0)
+    {
+        str += prefix_size;
+        *str_len -= prefix_size;
+    }
+
+    return str;
+}
 
 struct Codec
 {
@@ -42,6 +59,7 @@ std::string encodeHex(const BinaryData& binary)
 BinaryDataPtr decodeHex(const char* hex_str, size_t len)
 {
     BinaryDataPtr result;
+    hex_str = skip_prefix("0x", hex_str, &len);
 
     if (len & 1)
     {

--- a/multy_core/src/ethereum/ethereum_account.cpp
+++ b/multy_core/src/ethereum/ethereum_account.cpp
@@ -132,13 +132,12 @@ struct EthereumPrivateKey : public PrivateKey
         secp256k1_ecdsa_recoverable_signature_serialize_compact(
                 secp_ctx(), signature_data.data(), &recovery_id, &signature);
 
+        // NOTE: If we are to support pre-EIP155 signatures, we should add 27 to the recovery_id;
+        // Please see Ethereum yellow paper and EIP155
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
         signature_data.back() = static_cast<unsigned char>(recovery_id);
-        BinaryDataPtr result;
-        throw_if_error(
-                make_binary_data_from_bytes(
-                        signature_data.data(), signature_data.size(),
-                        reset_sp(result)));
-        return result;
+
+        return make_clone(as_binary_data(signature_data));
     }
 
     const KeyData& get_data() const

--- a/multy_test/test_common.cpp
+++ b/multy_test/test_common.cpp
@@ -44,14 +44,16 @@ const HexTestCase TestCases[] =
         {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
          0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0}
     },
+    {
+        "0x00",
+        {0x00}
+    }
 };
 
 const char* InvalidHexTestCases[] = {
     "q",
     "-x",
     "1.1",
-    // 0x prefix is not supported
-    "0x00"
 };
 
 class BinaryDataTestValidHex : public ::testing::TestWithParam<HexTestCase>

--- a/multy_test/test_ethereum_account.cpp
+++ b/multy_test/test_ethereum_account.cpp
@@ -191,4 +191,54 @@ GTEST_TEST(EthereumBlockchainTest, validate_address)
     EXPECT_ERROR(validate_address(ETH_MAINNET, "0xb826808a8c41e00b7c5d71f211f005a84a7b97949d5e765831e1da4e34c9b8295d2a622eee50f25af78241c1cb7cfff11bcf2a13fe65dee1e3b86fd79a4e3ed000"));
 }
 
+struct PersonalSignTestCase
+{
+    const char* private_key;
+    const char* message;
+    const char* expected_signature;
+};
+
+class PersonalSignTestP : public ::testing::TestWithParam<PersonalSignTestCase>
+{};
+
+TEST_P(PersonalSignTestP, sign_with_key)
+{
+    const PersonalSignTestCase& param = GetParam();
+    CharPtr signature;
+    HANDLE_ERROR(ethereum_personal_sign(
+            param.private_key,
+            param.message, reset_sp(signature)));
+
+    ASSERT_STREQ(param.expected_signature, signature.get());
+}
+
+// personal_sign test cases based on test cases from Metamask:
+// https://github.com/MetaMask/eth-sig-util/blob/a8659ff2da34ab31372c812c6d1569b072650269/test/index.js#L252
+static const PersonalSignTestCase META_MASK_PERSONAL_SIGN_TEST_CASES[] = {
+    {
+        "6969696969696969696969696969696969696969696969696969696969696969",
+        // "hello world"
+        "68656c6c6f20776f726c64",
+        "ce909e8ea6851bc36c007a0072d0524b07a3ff8d4e623aca4c71ca8e57250c4d0a3fc38fa8fbaaa81ead4b9f6bd03356b6f8bf18bccad167d78891636e1d69561b"
+    },
+    {
+        "6969696969696969696969696969696969696969696969696969696969696969",
+      // some random binary message from parity's test
+        "0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f",
+        "9ff8350cc7354b80740a3580d0e0fd4f1f02062040bc06b893d70906f8728bb5163837fd376bf77ce03b55e9bd092b32af60e86abce48f7b8d3539988ee5a9be1c",
+    },
+    {
+        "4545454545454545454545454545454545454545454545454545454545454545",
+        // random binary message data and pk from parity's test
+        "0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f",
+        "a2870db1d0c26ef93c7b72d2a0830fa6b841e0593f7186bc6c7cc317af8cf3a42fda03bd589a49949aa05db83300cdb553116274518dbe9d90c65d0213f4af491b"
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+        Metamask,
+        PersonalSignTestP,
+        ::testing::ValuesIn(META_MASK_PERSONAL_SIGN_TEST_CASES)
+);
+
 } // namespace


### PR DESCRIPTION
Added ethereum_personal_sign() API method;
Added tests for ethereum_personal_sign;
Stripping ocasional 0x prefix from hex-encoded strings upon decoding;
Added some comments regarding signing with private key Ethereum-way;
Minor refactoring of binary_data API implementation.